### PR TITLE
Fixed 404ing URL for Zulu

### DIFF
--- a/docs/getting-started/installation.jade
+++ b/docs/getting-started/installation.jade
@@ -24,7 +24,7 @@ block docs-content
 
   section
     :marked
-      ### Installing with [Zulu](https://zulu.sh) (recommended)
+      ### Installing with [Zulu](https://zulu.molovo.co) (recommended)
 
       Installing with Zulu will handle building ZUnit from source, and installing all dependencies for you.
 


### PR DESCRIPTION
looks like zulu.sh was just a redirect to https://zulu.molovo.co and is no longer in place.